### PR TITLE
Ensure last_access timestamp is reset on secret rotation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 node_modules
 bower_components
 
+**/.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/ckanext/auth/model.py
+++ b/ckanext/auth/model.py
@@ -59,6 +59,8 @@ class UserSecret(tk.BaseModel):
         else:
             user_secret.secret = secret_value
 
+        # last_access must be set to None (e.g. when rotating a user secret)
+        user_secret.last_access = None
         model.Session.add(user_secret)
         model.Session.commit()
 


### PR DESCRIPTION
This PR ensures that when a user's TOTP secret is rotated or updated, the `last_access` timestamp is explicitly reset to `None`. 

Without this reset, a rotated secret would incorrectly inherit the timestamp of the old secret's last usage. The next time a user attempts to login, they would not see a QR code for the new secret. 
